### PR TITLE
add: validation of signup form

### DIFF
--- a/src/@types/props.type.d.ts
+++ b/src/@types/props.type.d.ts
@@ -16,7 +16,7 @@ declare module 'props-type' {
     styleClass?: string;
     isWrong?: boolean;
     alertText?: string;
-    content?: string;
+    defaultValue?: string;
     type?: string;
     placeholder?: string;
     disabled?: boolean;

--- a/src/@types/props.type.d.ts
+++ b/src/@types/props.type.d.ts
@@ -17,6 +17,7 @@ declare module 'props-type' {
     isWrong?: boolean;
     alertText?: string;
     defaultValue?: string;
+    value?: string;
     type?: string;
     placeholder?: string;
     disabled?: boolean;

--- a/src/@types/props.type.d.ts
+++ b/src/@types/props.type.d.ts
@@ -86,4 +86,9 @@ declare module 'props-type' {
     subContent?: string;
     styleClass?: string;
   };
+
+  export type TermsProps = {
+    agree: boolean;
+    setAgree: React.Dispatch<React.SetStateAction<boolean>>;
+  };
 }

--- a/src/components/_common/Input.tsx
+++ b/src/components/_common/Input.tsx
@@ -7,7 +7,7 @@ const Input = ({
   styleClass,
   isWrong = false,
   alertText = '',
-  content = '',
+  defaultValue = '',
   type = 'text',
   placeholder,
   disabled = false,
@@ -26,7 +26,7 @@ const Input = ({
               name={label}
               className="input"
               disabled
-              defaultValue={content}
+              defaultValue={defaultValue}
             />
           ) : (
             <input
@@ -35,7 +35,7 @@ const Input = ({
               onChange={onChange}
               type={type}
               placeholder={placeholder}
-              defaultValue={content}
+              defaultValue={defaultValue}
             />
           )}
           {isAlertRequired && <p className="alert-text">{alertText}</p>}

--- a/src/components/_common/Input.tsx
+++ b/src/components/_common/Input.tsx
@@ -7,7 +7,8 @@ const Input = ({
   styleClass,
   isWrong = false,
   alertText = '',
-  defaultValue = '',
+  defaultValue,
+  value,
   type = 'text',
   placeholder,
   disabled = false,
@@ -35,7 +36,7 @@ const Input = ({
               onChange={onChange}
               type={type}
               placeholder={placeholder}
-              defaultValue={defaultValue}
+              value={value}
             />
           )}
           {isAlertRequired && <p className="alert-text">{alertText}</p>}

--- a/src/components/infoeditpage/InfoEdit.tsx
+++ b/src/components/infoeditpage/InfoEdit.tsx
@@ -35,13 +35,13 @@ const InfoEdit = () => {
         <Input
           label="이름"
           styleClass="row"
-          content={data.name}
+          defaultValue={data.name}
           disabled={true}
         />
         <Input
           label="아이디"
           styleClass="row"
-          content={data.id}
+          defaultValue={data.id}
           disabled={true}
         />
         <Input
@@ -90,7 +90,7 @@ const InfoEdit = () => {
             <Input
               label="연락처"
               styleClass="row"
-              content={data.phone}
+              defaultValue={data.phone}
               disabled={true}
             />
             <Btn

--- a/src/components/infoeditpage/InfoEdit.tsx
+++ b/src/components/infoeditpage/InfoEdit.tsx
@@ -11,6 +11,7 @@ const InfoEdit = () => {
 
   useEffect(() => {
     setData(mockUser);
+    setEmail(mockUser.email);
   }, []);
 
   const [pw, setPw] = useState('');
@@ -28,6 +29,10 @@ const InfoEdit = () => {
       setAlertText('비밀번호가 일치하지 않습니다.');
     }
   }, [pwCheck, pw]);
+
+  const handleEmail = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setEmail(e.target.value);
+  };
 
   return (
     <div className="infoedit-div">
@@ -103,7 +108,8 @@ const InfoEdit = () => {
         <Input
           label="이메일"
           styleClass="row"
-          onChange={(e) => setEmail(e.target.value)}
+          value={email}
+          onChange={handleEmail}
         />
       </div>
       <div className="btns-div">

--- a/src/components/mypage/info/UserCheckModal.tsx
+++ b/src/components/mypage/info/UserCheckModal.tsx
@@ -21,7 +21,7 @@ const UserCheckModal = ({ setModal }: ModalProps) => {
       </p>
       <Input
         label=""
-        content={data.id}
+        defaultValue={data.id}
         disabled={true}
         isAlertRequired={false}
       />

--- a/src/components/signuppage/form/CompanyForm.tsx
+++ b/src/components/signuppage/form/CompanyForm.tsx
@@ -3,82 +3,196 @@ import Input from 'components/_common/Input';
 import Btn from 'components/_common/Btn';
 import mockUser from '../../../assets/mock/info.json';
 import { InfoFormData } from 'data-type';
+import { validateId, validatePw } from '../../utils/ValidationUtils';
+import { parseComNum } from 'components/utils/ComNumUtils';
 
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 const CompanyForm = () => {
+  const navigate = useNavigate();
+
   const [data, setData] = useState<Partial<InfoFormData>>({});
 
   useEffect(() => {
     setData(mockUser);
   }, []);
 
+  // terms agree value useState
+  const [agree, setAgree] = useState(false);
+
+  // input value useStates
   const [id, setId] = useState('');
   const [pw, setPw] = useState('');
   const [pwCheck, setPwCheck] = useState('');
+  const [parsedComNum, setParsedComNum] = useState('');
   const [comNum, setComNum] = useState('');
   const [email, setEmail] = useState('');
-  const [isWrong, setIsWrong] = useState(false);
-  const [alertText, setAlertText] = useState('');
 
+  // alert-text value useStates
+  const [idAlert, setIdAlert] = useState('');
+  const [pwAlert, setPwAlert] = useState('');
+  const [pwCheckAlert, setPwCheckAlert] = useState('');
+
+  // isWrong props useStates
+  const [isIdWrong, setIsIdWrong] = useState(false);
+  const [isPwWrong, setIsPwWrong] = useState(false);
+  const [isPwCheckWrong, setIsPwCheckWrong] = useState(false);
+  const [isComNumWrong, setIsComNumWrong] = useState(false);
+
+  // id duplication check useState
+  const [idDuplCheck, setIdDuplCheck] = useState(false);
+
+  // validation of id
+  const handleId = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setId(value);
+    setIdDuplCheck(false);
+
+    if (validateId(value)) {
+      setIdAlert('');
+      setIsIdWrong(false);
+    } else {
+      setIdAlert('6~12자 이내의 영문, 숫자로 이루어져야 합니다.');
+      setIsIdWrong(true);
+    }
+  };
+
+  // validation of pw
+  const handlePw = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setPw(value);
+
+    if (validatePw(value)) {
+      setPwAlert('');
+      setIsPwWrong(false);
+    } else {
+      setPwAlert(
+        '8~20자 이내의 영문, 숫자, 특수기호 중 2종류로 조합되어야 합니다.',
+      );
+      setIsPwWrong(true);
+    }
+  };
+
+  // validation of pwCheck
   useEffect(() => {
     if (pwCheck === pw || !pwCheck) {
-      setIsWrong(false);
-      setAlertText('');
+      setIsPwCheckWrong(false);
+      setPwCheckAlert('');
     } else {
-      setIsWrong(true);
-      setAlertText('비밀번호가 일치하지 않습니다.');
+      setIsPwCheckWrong(true);
+      setPwCheckAlert('비밀번호가 일치하지 않습니다.');
     }
   }, [pwCheck, pw]);
 
+  // validation of comNum
+  const handleComNum = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    const parsedValue = parseComNum(value);
+    setParsedComNum(parsedValue);
+    setComNum(parsedValue.replace(/-/g, ''));
+    if (parsedValue.length == 12) {
+      setIsComNumWrong(false);
+    } else {
+      setIsComNumWrong(true);
+    }
+  };
+
+  // duplicate check button click event handler
+  const handleDuplClick = () => {
+    setIdAlert('사용 가능한 아이디입니다.');
+    setIdDuplCheck(true);
+    setIsIdWrong(false);
+  };
+
+  // signup button click event handler
+  const handleSignupClick = () => {
+    if (!id) {
+      setIsIdWrong(true);
+    }
+    if (!idDuplCheck) {
+      setIsIdWrong(true);
+    }
+    if (!pw) {
+      setIsPwWrong(true);
+    }
+    if (!pwCheck) {
+      setIsPwCheckWrong(true);
+    }
+    if (comNum.length !== 10) {
+      setIsComNumWrong(true);
+    }
+
+    if (
+      agree &&
+      !isIdWrong &&
+      idDuplCheck &&
+      !isPwWrong &&
+      !isPwCheckWrong &&
+      !isComNumWrong
+    ) {
+      navigate('/sign-up/complete');
+    } else {
+      alert('회원가입 약관 동의 및 정보 작성을 완료해 주세요.');
+    }
+  };
+
   return (
     <div className="signup-form-div">
-      <Terms />
+      <Terms agree={agree} setAgree={setAgree} />
       <div className="input-div inputs-div">
-        <Input label="이름" content={data.name} disabled={true} />
+        <Input label="이름" defaultValue={data.name} disabled={true} />
         <div className="input-div">
           <Input
             label="아이디"
-            onChange={(e) => setId(e.target.value)}
+            onChange={handleId}
             isRequired={true}
+            placeholder="6~12자 이내의 영문, 숫자만 가능"
+            isWrong={isIdWrong}
+            alertText={idAlert}
           />
           <Btn
             label="중복 확인"
-            onClick={() => console.log('중복 확인 클릭')}
+            onClick={handleDuplClick}
             styleClass="short-btn dark-green"
           />
         </div>
         <Input
           label="비밀번호"
-          onChange={(e) => setPw(e.target.value)}
+          onChange={handlePw}
           isRequired={true}
           type="password"
+          placeholder="8~12자 이내의 영문, 숫자, 특수기호 중 2종류 조합"
+          isWrong={isPwWrong}
+          alertText={pwAlert}
         />
         <Input
           label="비밀번호 확인"
           onChange={(e) => setPwCheck(e.target.value)}
           isRequired={true}
           type="password"
-          isWrong={isWrong}
-          alertText={alertText}
+          isWrong={isPwCheckWrong}
+          alertText={pwCheckAlert}
         />
         <Input
           label="사업자등록번호"
-          onChange={(e) => setComNum(e.target.value)}
+          onChange={handleComNum}
           isRequired={true}
+          isWrong={isComNumWrong}
+          value={parsedComNum}
         />
-        <Input label="전화번호" content={data.phone} disabled={true} />
+        <Input label="전화번호" defaultValue={data.phone} disabled={true} />
         <Input label="이메일" onChange={(e) => setEmail(e.target.value)} />
       </div>
       <div className="btns-div">
         <Btn
           label="취소"
-          onClick={() => (window.location.href = '/sign-up/user-type')}
+          onClick={() => navigate('/sign-up/user-type')}
           styleClass="abreast-btn white"
         />
         <Btn
           label="회원가입"
-          onClick={() => (window.location.href = '/sign-up/complete')}
+          onClick={handleSignupClick}
           styleClass="abreast-btn dark-green"
         />
       </div>

--- a/src/components/signuppage/form/SeniorForm.tsx
+++ b/src/components/signuppage/form/SeniorForm.tsx
@@ -3,76 +3,162 @@ import Input from 'components/_common/Input';
 import Btn from 'components/_common/Btn';
 import mockUser from '../../../assets/mock/info.json';
 import { InfoFormData } from 'data-type';
+import { validateId, validatePw } from '../../utils/ValidationUtils';
 
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 const SeniorForm = () => {
+  const navigate = useNavigate();
+
   const [data, setData] = useState<Partial<InfoFormData>>({});
 
   useEffect(() => {
     setData(mockUser);
   }, []);
 
+  // terms agree value useState
+  const [agree, setAgree] = useState(false);
+
+  // input value useStates
   const [id, setId] = useState('');
   const [pw, setPw] = useState('');
   const [pwCheck, setPwCheck] = useState('');
   const [email, setEmail] = useState('');
-  const [isWrong, setIsWrong] = useState(false);
-  const [alertText, setAlertText] = useState('');
 
+  // alert-text value useStates
+  const [idAlert, setIdAlert] = useState('');
+  const [pwAlert, setPwAlert] = useState('');
+  const [pwCheckAlert, setPwCheckAlert] = useState('');
+
+  // isWrong props useStates
+  const [isIdWrong, setIsIdWrong] = useState(false);
+  const [isPwWrong, setIsPwWrong] = useState(false);
+  const [isPwCheckWrong, setIsPwCheckWrong] = useState(false);
+
+  // id duplication check useState
+  const [idDuplCheck, setIdDuplCheck] = useState(false);
+
+  // validation of id
+  const handleId = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setId(value);
+    setIdDuplCheck(false);
+
+    if (validateId(value)) {
+      setIdAlert('');
+      setIsIdWrong(false);
+    } else {
+      setIdAlert('6~12자 이내의 영문, 숫자로 이루어져야 합니다.');
+      setIsIdWrong(true);
+    }
+  };
+
+  // validation of pw
+  const handlePw = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setPw(value);
+
+    if (validatePw(value)) {
+      setPwAlert('');
+      setIsPwWrong(false);
+    } else {
+      setPwAlert(
+        '8~20자 이내의 영문, 숫자, 특수기호 중 2종류로 조합되어야 합니다.',
+      );
+      setIsPwWrong(true);
+    }
+  };
+
+  // validation of pwCheck
   useEffect(() => {
     if (pwCheck === pw || !pwCheck) {
-      setIsWrong(false);
-      setAlertText('');
+      setIsPwCheckWrong(false);
+      setPwCheckAlert('');
     } else {
-      setIsWrong(true);
-      setAlertText('비밀번호가 일치하지 않습니다.');
+      setIsPwCheckWrong(true);
+      setPwCheckAlert('비밀번호가 일치하지 않습니다.');
     }
   }, [pwCheck, pw]);
 
+  // duplicate check button click event handler
+  const handleDuplClick = () => {
+    setIdAlert('사용 가능한 아이디입니다.');
+    setIdDuplCheck(true);
+    setIsIdWrong(false);
+  };
+
+  // signup button click event handler
+  const handleSignupClick = () => {
+    if (!id) {
+      setIsIdWrong(true);
+    }
+    if (!idDuplCheck) {
+      setIsIdWrong(true);
+    }
+    if (!pw) {
+      setIsPwWrong(true);
+    }
+    if (!pwCheck) {
+      setIsPwCheckWrong(true);
+    }
+
+    if (agree && !isIdWrong && idDuplCheck && !isPwWrong && !isPwCheckWrong) {
+      navigate('/sign-up/complete');
+    } else {
+      alert('회원가입 약관 동의 및 정보 작성을 완료해 주세요.');
+    }
+  };
+
   return (
     <div className="signup-form-div">
-      <Terms />
+      <Terms agree={agree} setAgree={setAgree} />
       <div className="input-div inputs-div">
-        <Input label="이름" content={data.name} disabled={true} />
+        <Input label="이름" defaultValue={data.name} disabled={true} />
         <div className="input-div">
           <Input
             label="아이디"
-            onChange={(e) => setId(e.target.value)}
+            onChange={handleId}
             isRequired={true}
+            placeholder="6~12자 이내의 영문, 숫자만 가능"
+            isWrong={isIdWrong}
+            alertText={idAlert}
           />
           <Btn
             label="중복 확인"
-            onClick={() => console.log('중복 확인 클릭')}
+            onClick={handleDuplClick}
             styleClass="short-btn dark-green"
           />
         </div>
         <Input
           label="비밀번호"
-          onChange={(e) => setPw(e.target.value)}
+          onChange={handlePw}
           isRequired={true}
           type="password"
+          placeholder="8~12자 이내의 영문, 숫자, 특수기호 중 2종류 조합"
+          isWrong={isPwWrong}
+          alertText={pwAlert}
         />
         <Input
           label="비밀번호 확인"
           onChange={(e) => setPwCheck(e.target.value)}
           isRequired={true}
           type="password"
-          isWrong={isWrong}
-          alertText={alertText}
+          isWrong={isPwCheckWrong}
+          alertText={pwCheckAlert}
         />
-        <Input label="전화번호" content={data.phone} disabled={true} />
+        <Input label="전화번호" defaultValue={data.phone} disabled={true} />
         <Input label="이메일" onChange={(e) => setEmail(e.target.value)} />
       </div>
       <div className="btns-div">
         <Btn
           label="취소"
-          onClick={() => (window.location.href = '/sign-up/user-type')}
+          onClick={() => navigate('/sign-up/user-type')}
           styleClass="abreast-btn white"
         />
         <Btn
           label="회원가입"
-          onClick={() => (window.location.href = '/sign-up/complete')}
+          onClick={handleSignupClick}
           styleClass="abreast-btn dark-green"
         />
       </div>

--- a/src/components/signuppage/form/Terms.tsx
+++ b/src/components/signuppage/form/Terms.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
 
-const Terms = () => {
-  const [agree, setAgree] = useState(false);
+import { TermsProps } from 'props-type';
+
+const Terms = ({ agree, setAgree }: TermsProps) => {
   const [isOpen, setIsOpen] = useState(false);
 
   const handleOpen = () => {

--- a/src/components/utils/ComNumUtils.ts
+++ b/src/components/utils/ComNumUtils.ts
@@ -1,0 +1,13 @@
+export const parseComNum = (input: string) => {
+  const digits = input.replace(/\D/g, '');
+
+  if (digits.length >= 4 && digits.length < 6) {
+    return `${digits.substring(0, 3)}-${digits.substring(3)}`;
+  } else if (digits.length >= 6 && digits.length < 10) {
+    return `${digits.substring(0, 3)}-${digits.substring(3, 5)}-${digits.substring(5)}`;
+  } else if (digits.length >= 10) {
+    return `${digits.substring(0, 3)}-${digits.substring(3, 5)}-${digits.substring(5, 10)}`;
+  } else {
+    return digits;
+  }
+};

--- a/src/components/utils/PhoneUtils.ts
+++ b/src/components/utils/PhoneUtils.ts
@@ -1,0 +1,13 @@
+export const parsePhoneNumber = (input: string) => {
+  const digits = input.replace(/\D/g, '');
+
+  if (digits.length >= 3 && digits.length < 7) {
+    return `(${digits.substring(0, 3)}`;
+  } else if (digits.length >= 7 && digits.length < 11) {
+    return `(${digits.substring(0, 3)})-${digits.substring(3, 7)}`;
+  } else if (digits.length >= 11) {
+    return `(${digits.substring(0, 3)})-${digits.substring(3, 7)}-${digits.substring(7, 11)}`;
+  } else {
+    return digits;
+  }
+};

--- a/src/components/utils/ValidationUtils.ts
+++ b/src/components/utils/ValidationUtils.ts
@@ -1,0 +1,10 @@
+export const validateId = (value: string) => {
+  const expIdTest = /^[a-zA-Z0-9]{6,12}$/;
+  return expIdTest.test(value);
+};
+
+export const validatePw = (value: string) => {
+  const expPwTest =
+    /^(?=.*[a-zA-Z])(?=.*\d|.*[!@#$%^&*])[a-zA-Z\d!@#$%^&*]{8,20}$/;
+  return expPwTest.test(value);
+};

--- a/src/scss/pages/_signin.scss
+++ b/src/scss/pages/_signin.scss
@@ -64,13 +64,14 @@
   margin-bottom: 8rem;
 
   button {
+    color: $black;
+    cursor: pointer;
     @include pc {
       font-size: 2rem;
     }
     @include mobile {
       font-size: 1.8rem;
     }
-    cursor: pointer;
   }
   .signup {
     color: $dark-green;


### PR DESCRIPTION
## 개요

### 회원가입 폼
- 시니어, 기업 회원의 회원가입 입력 값 검증을 했습니다.
- 기업 회원의 사업자등록번호를 parsing하는 정규식을 구현했습니다.
### utils 폴더
- 정규식 파일을 넣어둔 utils 폴더를 생성했습니다.
- 사업자등록번호, 전화번호, 아이디와 비밀번호를 검증하는 함수 파일을 생성했습니다.
### Terms 컴포넌트
- 개인정보동의 여부에 대한 agree, setAgree를 props로 받아 회원가입 폼에서 관리하도록 했습니다.
### Input 컴포넌트
- props에서 defaultValue와 value를 나누어 전달하도록 변경했습니다.
- defaultValue는 disabled props가 true로 전달하는 경우에 사용하고, value는 변경 가능한 경우에 사용합니다.
### 변경 사항
- 로그인 페이지의 아이디 찾기, 비밀번호 찾기 버튼의 색을 검정으로 설정했습니다.

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
