### PR TITLE
feat: publish notice page

### DIFF
--- a/src/@types/props.type.d.ts
+++ b/src/@types/props.type.d.ts
@@ -113,4 +113,14 @@ declare module 'props-type' {
     }[];
     onTitleClick: (e: React.MouseEvent<HTMLElement, MouseEvent>) => void;
   };
+
+  export type NoticeListProps = {
+    isOld: boolean;
+  };
+
+  export type NoticeItemProps = {
+    name: string;
+    src: string;
+    type: string;
+  };
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ import SearchFilterPage from 'pages/SearchFilterPage';
 import AboutUsPage from 'pages/AboutUsPage';
 import SeniorTab from 'components/aboutuspage/SeniorTab';
 import CompanyTab from 'components/aboutuspage/CompanyTab';
+import NoticePage from 'pages/NoticePage';
 
 function App() {
   return (
@@ -60,6 +61,7 @@ function App() {
               <Route path="senior" element={<SeniorTab />} />
               <Route path="company" element={<CompanyTab />} />
             </Route>
+            <Route path="/notice" element={<NoticePage />} />
           </Routes>
         </Layout>
       </RecoilRoot>

--- a/src/assets/mock/noticelist.json
+++ b/src/assets/mock/noticelist.json
@@ -1,0 +1,30 @@
+[
+  {
+    "id": 1,
+    "name": "(주)개발코리아",
+    "src": "https://cdn.vectorstock.com/i/preview-1x/17/46/development-business-logo-template-vector-31471746.jpg",
+    "type": "채용 제안",
+    "isRead": false
+  },
+  {
+    "id": 2,
+    "name": "서울시니어센터",
+    "src": "https://goldenjob.or.kr/images/common/logo.jpg",
+    "type": "채용 제안",
+    "isRead": false
+  },
+  {
+    "id": 3,
+    "name": "이화여자대학교",
+    "src": "https://i.namu.wiki/i/ayDlxOs9HFBzgePxztJKfSDiUuNd8B-9PcWMbTxBhr4kwAEqbHfVo9Cuahbfi-cLKW2VO3lJ47Wi52SBl-iaQg.svg",
+    "type": "계약서 체결",
+    "isRead": true
+  },
+  {
+    "id": 4,
+    "name": "서울시청",
+    "src": "https://mblogthumb-phinf.pstatic.net/MjAxOTEyMDVfMTY2/MDAxNTc1NTA1MTI0MDU4.VCKXBYxcwd6OpvOaoHzUo34Z4aLpzt_oa7tmmRbQQcog.Lt9xPTDkNwNiUDxE6yoMzNO_kLAvKJm8OLwGjZuUGEAg.JPEG.appcomo/Emblem%EC%9D%91%EC%9A%A9%ED%98%95-1.jpg?type=w800",
+    "type": "채용 취소",
+    "isRead": false
+  }
+]

--- a/src/components/_common/layout/Header.tsx
+++ b/src/components/_common/layout/Header.tsx
@@ -49,7 +49,11 @@ const Header = () => {
           </div>
           {isLogin ? (
             <div style={{ display: 'flex' }}>
-              <img className="header_icon" src={notice} />
+              <img
+                className="header_icon"
+                src={notice}
+                onClick={() => navigate('/notice')}
+              />
               <button
                 className="header_btn"
                 onClick={() => navigate('/my-page')}

--- a/src/components/mainpage/Contents.tsx
+++ b/src/components/mainpage/Contents.tsx
@@ -11,7 +11,7 @@ const Contents = () => {
     <>
       <div className="button-div">
         <div className="contents-wrapper">
-          <Link to="/about-us">
+          <Link to="/about-us/senior">
             <Content
               title="다시"
               content="서비스 소개 바로가기"

--- a/src/components/noticepage/NoticeItem.tsx
+++ b/src/components/noticepage/NoticeItem.tsx
@@ -1,0 +1,44 @@
+import Btn from 'components/_common/Btn';
+import { NoticeItemProps } from 'props-type';
+import { useEffect, useState } from 'react';
+
+const NoticeItem = ({ name, src, type }: NoticeItemProps) => {
+  const [text, setText] = useState('');
+  const [btnText, setBtnText] = useState('');
+  const handleType = (name: string, type: string) => {
+    if (type === '채용 제안') {
+      setText(name + '에서 채용 제안이 왔어요!');
+      setBtnText('제안 확인하기');
+    }
+    if (type === '채용 취소') {
+      setText(name + '에서 채용을 취소했어요.');
+      setBtnText('취소 사유 확인하기');
+    }
+    if (type === '계약서 체결') {
+      setText(name + '와 계약이 성사되었어요!');
+      setBtnText('계약서 확인하기');
+    }
+  };
+
+  useEffect(() => {
+    handleType(name, type);
+  }, [name, type]);
+
+  return (
+    <div className="noticeitem-div">
+      <div className="noticeitem-info-div">
+        <div className="noticeitem-img-div">
+          <img src={src} />
+        </div>
+        <p>{text}</p>
+      </div>
+      <Btn
+        label={btnText}
+        onClick={() => console.log(btnText + ' 클릭')}
+        styleClass="ntc-btn dark-green"
+      />
+    </div>
+  );
+};
+
+export default NoticeItem;

--- a/src/components/noticepage/NoticeList.tsx
+++ b/src/components/noticepage/NoticeList.tsx
@@ -1,0 +1,24 @@
+import { NoticeListProps } from 'props-type';
+import data from '../../assets/mock/noticelist.json';
+import NoticeItem from './NoticeItem';
+
+const NoticeList = ({ isOld }: NoticeListProps) => {
+  return (
+    <div className="noticelist-div">
+      {data.map((item) => {
+        return (
+          isOld === item.isRead && (
+            <NoticeItem
+              key={item.id}
+              name={item.name}
+              src={item.src}
+              type={item.type}
+            />
+          )
+        );
+      })}
+    </div>
+  );
+};
+
+export default NoticeList;

--- a/src/components/noticepage/NoticeTab.tsx
+++ b/src/components/noticepage/NoticeTab.tsx
@@ -1,0 +1,28 @@
+import { useState } from 'react';
+import NoticeList from './NoticeList';
+
+const NoticeTab = () => {
+  const [activeIndex, setActiveIndex] = useState<number>(0);
+  const tabType = [
+    { label: '새로운 알림', isOld: false },
+    { label: '지난 알림', isOld: true },
+  ];
+  return (
+    <div className="tab-div">
+      <div className="tab-wrapper">
+        {tabType.map((tab, index) => (
+          <div
+            key={index}
+            className={`${activeIndex === index && 'active'}`}
+            onClick={() => setActiveIndex(index)}
+          >
+            {tab.label}
+          </div>
+        ))}
+      </div>
+      <NoticeList isOld={tabType[activeIndex].isOld} />
+    </div>
+  );
+};
+
+export default NoticeTab;

--- a/src/components/signinpage/SignInTab.tsx
+++ b/src/components/signinpage/SignInTab.tsx
@@ -8,7 +8,7 @@ const SignInTab = () => {
     { label: '기업 회원', user: 'company' },
   ];
   return (
-    <div className="signin-tab">
+    <div className="tab-div">
       <div className="tab-wrapper">
         {tabType.map((tab, index) => (
           <div

--- a/src/components/signinpage/SignInTab.tsx
+++ b/src/components/signinpage/SignInTab.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import SignInForm from './SignInForm';
 
 const SignInTab = () => {
-  const [activeIndex, setactiveIndex] = useState<number>(0);
+  const [activeIndex, setActiveIndex] = useState<number>(0);
   const tabType = [
     { label: '시니어 회원', user: 'senior' },
     { label: '기업 회원', user: 'company' },
@@ -14,7 +14,7 @@ const SignInTab = () => {
           <div
             key={index}
             className={`${activeIndex === index && 'active'}`}
-            onClick={() => setactiveIndex(index)}
+            onClick={() => setActiveIndex(index)}
           >
             {tab.label}
           </div>

--- a/src/pages/NoticePage.tsx
+++ b/src/pages/NoticePage.tsx
@@ -1,0 +1,12 @@
+import Title from 'components/_common/Title';
+import NoticeTab from 'components/noticepage/NoticeTab';
+
+const NoticePage = () => {
+  return (
+    <>
+      <Title label="알림" />
+      <NoticeTab />
+    </>
+  );
+};
+export default NoticePage;

--- a/src/scss/components/_button.scss
+++ b/src/scss/components/_button.scss
@@ -124,3 +124,17 @@
     }
   }
 }
+
+/* NoticeItem button style */
+.ntc-btn {
+  @include btn;
+  width: 100%;
+  @include pc {
+    height: 6rem;
+    font-size: 2.8rem;
+  }
+  @include mobile {
+    height: 5rem;
+    font-size: 2rem;
+  }
+}

--- a/src/scss/components/_tab.scss
+++ b/src/scss/components/_tab.scss
@@ -1,0 +1,39 @@
+@import '../abstracts/mixin';
+@import '../abstracts/variables';
+
+/* tab style */
+.tab-div {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+
+  .tab-wrapper {
+    @include pc {
+      width: 64.2rem;
+      height: 6.4rem;
+      font-size: 3.6rem;
+    }
+    @include mobile {
+      width: 100%;
+      height: 4.5rem;
+      font-size: 2.4rem;
+    }
+    display: flex;
+    margin-bottom: 3rem;
+    cursor: pointer;
+
+    div {
+      display: flex;
+      justify-content: center;
+      width: 50%;
+      height: 100%;
+      font-weight: 600;
+      border-bottom: 0.1rem solid $light-gray;
+    }
+    .active {
+      border-bottom: 0.3rem solid $dark-green;
+      color: $dark-green;
+    }
+  }
+}

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -5,18 +5,19 @@
 @import 'base/reset';
 
 @import 'components/arrow';
+@import 'components/banner_btn';
+@import 'components/banner';
 @import 'components/button';
 @import 'components/infoForm';
 @import 'components/input';
 @import 'components/modal';
 @import 'components/picture';
 @import 'components/profile';
-@import 'components/title';
-@import 'components/tag';
-@import 'components/banner';
-@import 'components/banner_btn';
 @import 'components/resume_card';
 @import 'components/select';
+@import 'components/tab';
+@import 'components/tag';
+@import 'components/title';
 
 @import 'layout/footer';
 @import 'layout/header';
@@ -24,13 +25,14 @@
 @import 'layout/hamburger';
 
 @import 'pages/aboutus';
+@import 'pages/editmodal';
 @import 'pages/findpage';
 @import 'pages/infoedit';
 @import 'pages/main';
 @import 'pages/mypage';
-@import 'pages/signin';
-@import 'pages/signup';
+@import 'pages/notice';
 @import 'pages/resume';
 @import 'pages/search';
-@import 'pages/editmodal';
 @import 'pages/searchfilter';
+@import 'pages/signin';
+@import 'pages/signup';

--- a/src/scss/pages/_notice.scss
+++ b/src/scss/pages/_notice.scss
@@ -1,0 +1,70 @@
+@import '../abstracts/colors';
+@import '../abstracts/mixin';
+
+/* NoticeList style */
+.noticelist-div {
+  display: flex;
+  flex-direction: column;
+
+  @include mobile {
+    width: calc(100% - 4.8rem);
+  }
+}
+
+/* NoticeItem style */
+.noticeitem-div {
+  display: flex;
+  flex-direction: column;
+  background-color: $pale-gray;
+  padding: 2rem;
+  border-radius: 1rem;
+  @include pc {
+    width: 54.2rem;
+    margin-bottom: 3rem;
+  }
+  @include mobile {
+    margin-bottom: 2rem;
+  }
+}
+
+/* NoticeItem company's information div style */
+.noticeitem-info-div {
+  display: flex;
+  align-items: center;
+  margin-bottom: 2rem;
+  p {
+    width: 100%;
+    margin-left: 2rem;
+    font-weight: 600;
+    word-wrap: break-word;
+    @include pc {
+      font-size: 2.8rem;
+    }
+    @include mobile {
+      font-size: 2.4rem;
+    }
+  }
+}
+
+/* NoticeItem company's profile img style */
+.noticeitem-img-div {
+  background-color: $white;
+  border-radius: 100%;
+  display: flex;
+  align-items: center;
+  justify-items: center;
+  flex-shrink: 0;
+  overflow: hidden;
+  @include pc {
+    width: 7.5rem;
+    height: 7.5rem;
+  }
+  @include mobile {
+    width: 6.5rem;
+    height: 6.5rem;
+  }
+  img {
+    width: 100%;
+    height: auto;
+  }
+}

--- a/src/scss/pages/_signin.scss
+++ b/src/scss/pages/_signin.scss
@@ -1,43 +1,6 @@
 @import '../abstracts/mixin';
 @import '../abstracts/variables';
 
-/* sign in tab styles */
-.signin-tab {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-
-  .tab-wrapper {
-    @include pc {
-      width: 64.2rem;
-      height: 6.4rem;
-      font-size: 3.6rem;
-    }
-    @include mobile {
-      width: 100%;
-      height: 4.5rem;
-      font-size: 2.4rem;
-    }
-    display: flex;
-    margin-bottom: 3rem;
-    cursor: pointer;
-
-    div {
-      display: flex;
-      justify-content: center;
-      width: 50%;
-      height: 100%;
-      font-weight: 600;
-      border-bottom: 0.1rem solid $light-gray;
-    }
-    .active {
-      border-bottom: 0.3rem solid $dark-green;
-      color: $dark-green;
-    }
-  }
-}
-
 /* sign in form styles */
 .signin-form {
   display: flex;


### PR DESCRIPTION
## 개요

![image](https://github.com/Gamja-dori/Gamja-Frontend/assets/100225783/7146835b-19da-43a5-a444-acb7a317fecc)

- 알림 페이지를 퍼블리싱 했습니다.(PC뷰, 모바일뷰)
- 헤더의 종 이모지 클릭 시 '/notice' 페이지로 이동하도록 연결했습니다.
- 로그인 페이지의 tab 스타일을 _tab.scss로 분리하고 알림 페이지에서도 사용했습니다.
- 메인 페이지의 서비스 소개 컴포넌트 클릭 시 '/about-us/senior' 페이지로 이동하도록 수정했습니다.
- 오타를 수정했습니다. (setactiveIndex -> setActiveIndex)

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
