### PR TITLE
feat: connect signout, token refresh, signup funcs api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "antd": "^5.14.1",
         "axios": "^1.6.8",
         "install": "^0.13.0",
+        "moment": "^2.30.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-responsive": "^9.0.2",
@@ -13560,6 +13561,14 @@
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "antd": "^5.14.1",
     "axios": "^1.6.8",
     "install": "^0.13.0",
+    "moment": "^2.30.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-responsive": "^9.0.2",

--- a/src/@types/data.type.d.ts
+++ b/src/@types/data.type.d.ts
@@ -1,10 +1,10 @@
 declare module 'data-type' {
   export type InfoFormData = {
-    id: number;
     name: string;
     username: string;
     phone_number: string;
     email: string;
+    id?: number;
     is_senior?: boolean;
     is_enterprise?: boolean;
 

--- a/src/api/company_user.ts
+++ b/src/api/company_user.ts
@@ -10,7 +10,7 @@ export const SignupCompany = async ({
   business_number,
 }: SignupData) => {
   try {
-    const res = await http.post('/users/signup/', {
+    const res = await http.post('/users/enterprise/signup/', {
       user: {
         username: username,
         email: email,

--- a/src/api/http.ts
+++ b/src/api/http.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import moment from 'moment';
 
 export const http = axios.create({
   baseURL: process.env.REACT_APP_API_URL,
@@ -9,4 +10,40 @@ http.interceptors.request.use(function (config) {
   const token = window.localStorage.getItem('access') ?? false;
   config.headers.Authorization = token ? `Bearer ${token}` : null;
   return config;
+});
+
+// Create an axios instance for headerless refresh
+const refreshHTTP = axios.create({
+  baseURL: process.env.REACT_APP_API_URL,
+  withCredentials: true,
+});
+
+// Check interceptors token expiration for axios request
+http.interceptors.request.use(async (config) => {
+  try {
+    const refresh = localStorage.getItem('refresh');
+    const expireAt = localStorage.getItem('expireAt');
+    let access = localStorage.getItem('access') ?? '';
+
+    // Refresh token if the difference between the time stored in localStorage and the current time is less than 0
+    if (moment(expireAt).diff(moment()) < 0 && refresh) {
+      const res = await refreshHTTP.post('/users/token/refresh/', {
+        refresh: refresh,
+      });
+      access = res.data.access;
+      localStorage.setItem('access', access);
+      localStorage.setItem(
+        'expireAt',
+        moment().add(2, 'minute').format('yyyy-MM-DD HH:mm:ss'),
+      );
+    }
+    config.headers.Authorization = access ? `Bearer ${access}` : null;
+    return config;
+  } catch (err) {
+    console.log('리프레시 에러', err);
+    localStorage.clear();
+    alert('토큰이 만료되었습니다.\n다시 로그인해 주세요.');
+    window.location.reload();
+    return Promise.reject(err);
+  }
 });

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -1,8 +1,8 @@
 import { http } from './http';
 
-export const Logout = async () => {
+export const Signout = async () => {
   try {
-    const res = await http.delete('/users/logout');
+    const res = await http.post('/users/logout/');
     console.log('로그아웃 성공');
     return res;
   } catch (err) {

--- a/src/components/_common/layout/Hamburger.tsx
+++ b/src/components/_common/layout/Hamburger.tsx
@@ -8,6 +8,7 @@ import user from './../../../assets/icons/hamburger/mono-user.svg';
 import arrow from './../../../assets/icons/hamburger/arrow-down.svg';
 import setting from './../../../assets/icons/hamburger/setting.svg';
 import profile from './../../../assets/images/profile.png';
+import { Signout } from 'api/user';
 
 const HamburgerAccordion = ({
   title,
@@ -94,6 +95,16 @@ const Hamburger = ({ setIsOpen, isLogin }: HamburgerProps) => {
     },
   ];
 
+  const handleSignout = async () => {
+    const res = await Signout();
+    if (res?.status === 202) {
+      navigate('/');
+      window.localStorage.clear();
+      window.location.href = '/';
+      setIsOpen(false);
+    }
+  };
+
   return (
     <>
       <div className="modal-bg-div" />
@@ -156,7 +167,9 @@ const Hamburger = ({ setIsOpen, isLogin }: HamburgerProps) => {
         />
         {isLogin && (
           <div className="hamburger-btn-container">
-            <div className="btn">로그아웃</div>
+            <div className="btn" onClick={handleSignout}>
+              로그아웃
+            </div>
             <div className="btn">회원탈퇴</div>
           </div>
         )}

--- a/src/components/findidpage/FindIdForm.tsx
+++ b/src/components/findidpage/FindIdForm.tsx
@@ -27,12 +27,12 @@ const FindIdForm = () => {
       <div className="btns-div">
         <Btn
           label="취소"
-          onClick={() => navigate('/sign-in')}
+          onClick={() => navigate('/sign-in', { replace: true })}
           styleClass="abreast-btn white"
         />
         <Btn
           label="아이디 찾기"
-          onClick={() => navigate('/find/id/result')}
+          onClick={() => navigate('/find/id/result', { replace: true })}
           styleClass="abreast-btn dark-green"
         />
       </div>

--- a/src/components/findidpage/FindIdResult.tsx
+++ b/src/components/findidpage/FindIdResult.tsx
@@ -12,12 +12,12 @@ const FindIdResult = () => {
       <div className="btns-div">
         <Btn
           label="로그인하기"
-          onClick={() => navigate('/sign-in')}
+          onClick={() => navigate('/sign-in', { replace: true })}
           styleClass="abreast-btn dark-green"
         />
         <Btn
           label="비밀번호 찾기"
-          onClick={() => navigate('/find/pw/form')}
+          onClick={() => navigate('/find/pw/form', { replace: true })}
           styleClass="abreast-btn white"
         />
       </div>

--- a/src/components/findpwpage/FindPwForm.tsx
+++ b/src/components/findpwpage/FindPwForm.tsx
@@ -28,12 +28,12 @@ const FindPwForm = () => {
       <div className="btns-div">
         <Btn
           label="취소"
-          onClick={() => navigate('/sign-in')}
+          onClick={() => navigate('/sign-in', { replace: true })}
           styleClass="abreast-btn white"
         />
         <Btn
           label="비밀번호 찾기"
-          onClick={() => navigate('/find/pw/reset')}
+          onClick={() => navigate('/find/pw/reset', { replace: true })}
           styleClass="abreast-btn dark-green"
         />
       </div>

--- a/src/components/findpwpage/FindPwReset.tsx
+++ b/src/components/findpwpage/FindPwReset.tsx
@@ -18,12 +18,12 @@ const FindPwReset = () => {
       <div className="btns-div">
         <Btn
           label="취소"
-          onClick={() => navigate('/sign-in')}
+          onClick={() => navigate('/sign-in', { replace: true })}
           styleClass="abreast-btn white"
         />
         <Btn
           label="확인"
-          onClick={() => navigate('/sign-in')}
+          onClick={() => navigate('/sign-in', { replace: true })}
           styleClass="abreast-btn dark-green"
         />
       </div>

--- a/src/components/mypage/defaultResume/DefaultResume.tsx
+++ b/src/components/mypage/defaultResume/DefaultResume.tsx
@@ -5,7 +5,7 @@ import { useRecoilValue } from 'recoil';
 import { UserProfileAtom } from 'recoil/UserProfile';
 
 const DefaultResume = () => {
-  const UserProfileData = useRecoilValue(UserProfileAtom);
+  const userProfileData = useRecoilValue(UserProfileAtom);
   const navigate = useNavigate();
 
   return (
@@ -18,7 +18,7 @@ const DefaultResume = () => {
           styleClass="mypage-btn dark-green"
         />
       </div>
-      {UserProfileData.default_resume === -1 ? (
+      {userProfileData.default_resume === -1 ? (
         <div className="mypage-semi-outline light-gray">
           <p className="mypage-semi-notice">기본 이력서가 아직 없어요!</p>
         </div>

--- a/src/components/mypage/info/InfoForm.tsx
+++ b/src/components/mypage/info/InfoForm.tsx
@@ -1,9 +1,12 @@
 import { useEffect, useState } from 'react';
 import Btn from 'components/_common/Btn';
 import WithdrawalModal from './WithdrawalModal';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { UserProfileAtom } from 'recoil/UserProfile';
 import { parsePhoneNumber } from 'components/utils/PhoneUtils';
+import { Signout } from 'api/user';
+import { useNavigate } from 'react-router-dom';
+import { SigninStateAtom } from 'recoil/Signin';
 
 const InfoForm = () => {
   const [phoneNumber, setPhoneNumber] = useState('');
@@ -15,6 +18,14 @@ const InfoForm = () => {
     const parsed_result = parsePhoneNumber(UserProfileData.phone_number);
     setPhoneNumber(parsed_result);
   }, [UserProfileData]);
+
+  const handleSignout = async () => {
+    const res = await Signout();
+    if (res?.status === 202) {
+      window.localStorage.clear();
+      window.location.href = '/';
+    }
+  };
 
   return (
     <div className="infoForm-div">
@@ -37,7 +48,7 @@ const InfoForm = () => {
       <div className="infoForm-btn-box">
         <Btn
           label="로그아웃"
-          onClick={() => console.log('로그아웃 클릭')}
+          onClick={handleSignout}
           styleClass="mini-btn light-gray"
         />
         <Btn

--- a/src/components/mypage/info/InfoForm.tsx
+++ b/src/components/mypage/info/InfoForm.tsx
@@ -10,12 +10,12 @@ const InfoForm = () => {
   const [phoneNumber, setPhoneNumber] = useState('');
   const [modal, setModal] = useState(false);
 
-  const UserProfileData = useRecoilValue(UserProfileAtom);
+  const userProfileData = useRecoilValue(UserProfileAtom);
 
   useEffect(() => {
-    const parsed_result = parsePhoneNumber(UserProfileData.phone_number);
+    const parsed_result = parsePhoneNumber(userProfileData.phone_number);
     setPhoneNumber(parsed_result);
-  }, [UserProfileData]);
+  }, [userProfileData]);
 
   const handleSignout = async () => {
     const res = await Signout();
@@ -29,11 +29,11 @@ const InfoForm = () => {
     <div className="infoForm-div">
       <div className="infoForm-box">
         <p>이름</p>
-        <p>{UserProfileData.name}</p>
+        <p>{userProfileData.name}</p>
       </div>
       <div className="infoForm-box">
         <p>아이디</p>
-        <p>{UserProfileData.username}</p>
+        <p>{userProfileData.username}</p>
       </div>
       <div className="infoForm-box">
         <p>연락처</p>
@@ -41,7 +41,7 @@ const InfoForm = () => {
       </div>
       <div className="infoForm-box">
         <p>이메일</p>
-        <p>{UserProfileData.email}</p>
+        <p>{userProfileData.email}</p>
       </div>
       <div className="infoForm-btn-box">
         <Btn

--- a/src/components/mypage/info/InfoForm.tsx
+++ b/src/components/mypage/info/InfoForm.tsx
@@ -1,12 +1,10 @@
 import { useEffect, useState } from 'react';
 import Btn from 'components/_common/Btn';
 import WithdrawalModal from './WithdrawalModal';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilValue } from 'recoil';
 import { UserProfileAtom } from 'recoil/UserProfile';
 import { parsePhoneNumber } from 'components/utils/PhoneUtils';
 import { Signout } from 'api/user';
-import { useNavigate } from 'react-router-dom';
-import { SigninStateAtom } from 'recoil/Signin';
 
 const InfoForm = () => {
   const [phoneNumber, setPhoneNumber] = useState('');

--- a/src/components/mypage/info/UserCheckModal.tsx
+++ b/src/components/mypage/info/UserCheckModal.tsx
@@ -7,7 +7,7 @@ import { useRecoilValue } from 'recoil';
 import { UserProfileAtom } from 'recoil/UserProfile';
 
 const UserCheckModal = ({ setModal }: ModalProps) => {
-  const UserProfileData = useRecoilValue(UserProfileAtom);
+  const userProfileData = useRecoilValue(UserProfileAtom);
   const navigate = useNavigate();
 
   return (
@@ -18,7 +18,7 @@ const UserCheckModal = ({ setModal }: ModalProps) => {
       </p>
       <Input
         label=""
-        defaultValue={UserProfileData.username}
+        defaultValue={userProfileData.username}
         disabled={true}
         isAlertRequired={false}
       />

--- a/src/components/mypage/profile/Profile.tsx
+++ b/src/components/mypage/profile/Profile.tsx
@@ -4,7 +4,7 @@ import { useRecoilValue } from 'recoil';
 import { UserProfileAtom } from 'recoil/UserProfile';
 
 const Profile = () => {
-  const UserProfileData = useRecoilValue(UserProfileAtom);
+  const userProfileData = useRecoilValue(UserProfileAtom);
 
   return (
     <div className="mypage-profile-div">
@@ -13,10 +13,10 @@ const Profile = () => {
         <Picture />
         <div className="profile-user-box">
           <div className="profile-username">
-            <p>{UserProfileData.name}</p>
+            <p>{userProfileData.name}</p>
             <p>님</p>
           </div>
-          {UserProfileData.is_senior ? (
+          {userProfileData.is_senior ? (
             <UserTag user={'시니어 회원'} />
           ) : (
             <UserTag user={'기업 회원'} />

--- a/src/components/signinpage/SignInForm.tsx
+++ b/src/components/signinpage/SignInForm.tsx
@@ -88,7 +88,7 @@ const SignInForm = ({ user }: UserProps) => {
 
   // mini btns click event handler
   const handleBtnClick = (path: string) => {
-    navigate(path);
+    navigate(path, { replace: true });
   };
 
   return (
@@ -127,7 +127,8 @@ const SignInForm = ({ user }: UserProps) => {
         <div className="line"></div>
         <button
           className="signup"
-          onClick={() => handleBtnClick('/sign-up/verification')}
+          // onClick={() => handleBtnClick('/sign-up/verification')} temporary setting
+          onClick={() => handleBtnClick('/sign-up/user-type')}
         >
           회원가입
         </button>

--- a/src/components/signinpage/SignInForm.tsx
+++ b/src/components/signinpage/SignInForm.tsx
@@ -10,6 +10,7 @@ import { useSetRecoilState } from 'recoil';
 
 import { useNavigate } from 'react-router-dom';
 import { SigninStateAtom, SigninAtom } from 'recoil/Signin';
+import moment from 'moment';
 
 const SignInForm = ({ user }: UserProps) => {
   const setSigninAtom = useSetRecoilState(SigninAtom);
@@ -77,6 +78,10 @@ const SignInForm = ({ user }: UserProps) => {
         isSignin: true,
         isSenior: data.is_senior,
       });
+      localStorage.setItem(
+        'expireAt',
+        moment().add(2, 'minute').format('yyyy-MM-DD HH:mm:ss'),
+      );
       navigate(-1);
     }
   };

--- a/src/components/signuppage/complete/Complete.tsx
+++ b/src/components/signuppage/complete/Complete.tsx
@@ -14,7 +14,7 @@ const Complete = () => {
       </p>
       <Btn
         label="로그인하러 가기"
-        onClick={() => navigate('/sign-in')}
+        onClick={() => navigate('/sign-in', { replace: true })}
         styleClass="long-btn dark-green"
       />
     </div>

--- a/src/components/signuppage/form/CompanyForm.tsx
+++ b/src/components/signuppage/form/CompanyForm.tsx
@@ -1,22 +1,22 @@
 import Terms from './Terms';
 import Input from 'components/_common/Input';
 import Btn from 'components/_common/Btn';
-import mockUser from '../../../assets/mock/info.json';
 import { InfoFormData } from 'data-type';
 import { validateId, validatePw } from '../../utils/ValidationUtils';
 import { parseComNum } from 'components/utils/ComNumUtils';
 
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { SignupCompany } from 'api/company_user';
 
 const CompanyForm = () => {
   const navigate = useNavigate();
 
-  const [data, setData] = useState<Partial<InfoFormData>>({});
+  // const [data, setData] = useState<Partial<InfoFormData>>({});
 
-  useEffect(() => {
-    setData(mockUser);
-  }, []);
+  // temp settings
+  const [name, setName] = useState('');
+  const [phone_number, setPhone_number] = useState('');
 
   // terms agree value useState
   const [agree, setAgree] = useState(false);
@@ -133,7 +133,7 @@ const CompanyForm = () => {
   };
 
   // signup button click event handler
-  const handleSignupClick = () => {
+  const handleSignupClick = async () => {
     if (isFilled()) {
       if (
         agree &&
@@ -143,7 +143,17 @@ const CompanyForm = () => {
         !isPwCheckWrong &&
         !isComNumWrong
       ) {
-        navigate('/sign-up/complete');
+        const res = await SignupCompany({
+          username: id,
+          email: email,
+          password: pw,
+          name: name,
+          phone_number: phone_number,
+          business_number: comNum,
+        });
+        if (res?.status === 201) {
+          navigate('/sign-up/complete', { replace: true });
+        }
       } else {
         alert('회원가입 약관 동의 및 정보 작성을 완료해 주세요.');
       }
@@ -156,7 +166,9 @@ const CompanyForm = () => {
     <div className="signup-form-div">
       <Terms agree={agree} setAgree={setAgree} />
       <div className="input-div inputs-div">
-        <Input label="이름" defaultValue={data.name} disabled={true} />
+        {/* temporary setting */}
+        {/* <Input label="이름" defaultValue={data.name} disabled={true} /> */}
+        <Input label="이름" onChange={(e) => setName(e.target.value)} />
         <div className="input-div">
           <Input
             label="아이디"
@@ -194,10 +206,15 @@ const CompanyForm = () => {
           isWrong={isComNumWrong}
           value={parsedComNum}
         />
-        <Input
+        {/* temporary setting */}
+        {/* <Input
           label="전화번호"
           defaultValue={data.phone_number}
           disabled={true}
+        /> */}
+        <Input
+          label="전화번호"
+          onChange={(e) => setPhone_number(e.target.value)}
         />
         <Input label="이메일" onChange={(e) => setEmail(e.target.value)} />
       </div>

--- a/src/components/signuppage/form/SeniorForm.tsx
+++ b/src/components/signuppage/form/SeniorForm.tsx
@@ -1,21 +1,21 @@
 import Terms from './Terms';
 import Input from 'components/_common/Input';
 import Btn from 'components/_common/Btn';
-import mockUser from '../../../assets/mock/info.json';
 import { InfoFormData } from 'data-type';
 import { validateId, validatePw } from '../../utils/ValidationUtils';
 
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { SignupSenior } from 'api/senior_user';
 
 const SeniorForm = () => {
   const navigate = useNavigate();
 
-  const [data, setData] = useState<Partial<InfoFormData>>({});
+  // const [data, setData] = useState<Partial<InfoFormData>>({});
 
-  useEffect(() => {
-    setData(mockUser);
-  }, []);
+  // temp settings
+  const [name, setName] = useState('');
+  const [phone_number, setPhone_number] = useState('');
 
   // terms agree value useState
   const [agree, setAgree] = useState(false);
@@ -113,10 +113,19 @@ const SeniorForm = () => {
   };
 
   // signup button click event handler
-  const handleSignupClick = () => {
+  const handleSignupClick = async () => {
     if (isFilled()) {
       if (agree && !isIdWrong && idDuplCheck && !isPwWrong && !isPwCheckWrong) {
-        navigate('/sign-up/complete');
+        const res = await SignupSenior({
+          username: id,
+          email: email,
+          password: pw,
+          name: name,
+          phone_number: phone_number,
+        });
+        if (res?.status === 201) {
+          navigate('/sign-up/complete', { replace: true });
+        }
       } else {
         alert('회원가입 약관 동의 및 정보 작성을 완료해 주세요.');
       }
@@ -129,7 +138,9 @@ const SeniorForm = () => {
     <div className="signup-form-div">
       <Terms agree={agree} setAgree={setAgree} />
       <div className="input-div inputs-div">
-        <Input label="이름" defaultValue={data.name} disabled={true} />
+        {/* temporary setting */}
+        {/* <Input label="이름" defaultValue={data.name} disabled={true} /> */}
+        <Input label="이름" onChange={(e) => setName(e.target.value)} />
         <div className="input-div">
           <Input
             label="아이디"
@@ -160,10 +171,15 @@ const SeniorForm = () => {
           isWrong={isPwCheckWrong}
           alertText={pwCheckAlert}
         />
-        <Input
+        {/* temporary setting */}
+        {/* <Input
           label="전화번호"
           defaultValue={data.phone_number}
           disabled={true}
+        /> */}
+        <Input
+          label="전화번호"
+          onChange={(e) => setPhone_number(e.target.value)}
         />
         <Input label="이메일" onChange={(e) => setEmail(e.target.value)} />
       </div>

--- a/src/components/signuppage/usertype/TypeContent.tsx
+++ b/src/components/signuppage/usertype/TypeContent.tsx
@@ -3,11 +3,14 @@ import { useEffect, useState } from 'react';
 
 import senior from '../../../assets/icons/senior.svg';
 import company from '../../../assets/icons/company.svg';
+import { useNavigate } from 'react-router-dom';
 
 const TypeContent = ({ user }: UserProps) => {
   const [color, setColor] = useState('dark-green');
   const [imgSrc, setImgSrc] = useState('');
   const [path, setPath] = useState('');
+
+  const navigate = useNavigate();
 
   useEffect(() => {
     if (user === '시니어') {
@@ -24,7 +27,7 @@ const TypeContent = ({ user }: UserProps) => {
   return (
     <div
       className={`${color} signup-type-div`}
-      onClick={() => (window.location.href = `/sign-up/${path}/form`)}
+      onClick={() => navigate(`/sign-up/${path}/form`, { replace: true })}
     >
       <div>
         <p>{user} 회원가입</p>

--- a/src/components/signuppage/verification/Verification.tsx
+++ b/src/components/signuppage/verification/Verification.tsx
@@ -17,7 +17,7 @@ const Verification = () => {
       </p>
       <Btn
         label="휴대폰 본인 인증"
-        onClick={() => navigate('/sign-up/user-type')}
+        onClick={() => navigate('/sign-up/user-type', { replace: true })}
         styleClass="long-btn dark-green"
       />
       <KakaoBtn />

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -14,7 +14,7 @@ import Suggestion from 'components/mypage/suggestion/Suggestion';
 import { useNavigate } from 'react-router-dom';
 
 const MyPage = () => {
-  const SigninData = useRecoilValue(SigninAtom);
+  const signinData = useRecoilValue(SigninAtom);
   const [userProfileData, setUserProfileData] = useRecoilState(UserProfileAtom);
 
   const { isSignin } = useRecoilValue(SigninStateAtom);
@@ -57,8 +57,8 @@ const MyPage = () => {
   };
 
   useEffect(() => {
-    const id = SigninData.id;
-    const isSenior = SigninData.is_senior;
+    const id = signinData.id;
+    const isSenior = signinData.is_senior;
     if (id !== -1) {
       if (isSenior) {
         getSeniorData(id);
@@ -66,7 +66,7 @@ const MyPage = () => {
         getCompanyData(id);
       }
     }
-  }, [SigninData]);
+  }, [signinData]);
 
   const isMobile = useMediaQuery({
     query: '(max-width:802px)',


### PR DESCRIPTION
## 개요

- 로그아웃 api 연결 완료했습니다.
로그아웃과 로그인 여부 로직이 살짝 겹쳐서 로그아웃에는 window.location.href를 사용해서 홈으로 이동했습니다.
- 토큰 리프레시 api 연결 완료했습니다.
http.ts 파일에 생성했습니다.
moment 라이브러리 설치 후 로그인 시 expiredAt 값을 저장하여 interceptors를 이용해서 토큰을 재발급받습니다.
- 몇 가지 state 이름을 변경했습니다.
- 미사용 import를 삭제했습니다.
- 회원가입 api를 연결했습니다.
임시로 이름, 전화번호 필드를 입력 가능하게 바꿨습니다.
- 몇몇 navigate에 replace: true를 설정했습니다.
로그인 성공 시 navigate(-1)가 실행되는데 이때 회원가입이나 아이디, 비밀번호 찾기에 로그인 바로가기 버튼이 연결되어 있어서 로직이 꼬이게 되어 이 코드를 추가했습니다.

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
