### PR TITLE
fix: change review settings from suggestion pages

### DIFF
--- a/src/components/suggestionpage/management/ManagementItem.tsx
+++ b/src/components/suggestionpage/management/ManagementItem.tsx
@@ -12,8 +12,11 @@ const ManagementItem = ({ item }: ManagementItemProps) => {
 
   const setResumeData = useSetRecoilState(ResumeDetailAtom);
 
-  const handleReviewCreateClick = () => {
-    getResumeDetail(item.resume_id);
+  const handleReviewCreateClick = async () => {
+    const res = await getResumeDetail(item.resume_id);
+    if (res) {
+      navigate(`/review/new/${item.suggest_id}`);
+    }
   };
 
   const getResumeDetail = async (resume_id: number) => {
@@ -26,11 +29,24 @@ const ManagementItem = ({ item }: ManagementItemProps) => {
           resume_id: res?.data.resume_id,
           name: res?.data.name,
           profile_image: res?.data.profile_image,
+          review_avg: res?.data.review_avg,
           is_verified: res?.data.is_verified,
           successfully_get: true,
         };
       });
-      navigate(`/review/new/${item.suggest_id}`);
+      return true;
+    }
+    return false;
+  };
+
+  const handleProfileClick = async () => {
+    if (item.progress === 'is_paid' || item.progress === 'is_reviewed') {
+      const res = await getResumeDetail(item.resume_id);
+      if (res) {
+        navigate(`/suggestion/complete/${item.suggest_id}`);
+      }
+    } else {
+      navigate(`/search/detail/${item.resume_id}`);
     }
   };
 
@@ -38,13 +54,15 @@ const ManagementItem = ({ item }: ManagementItemProps) => {
     <div className="resume-long-card">
       <div
         className="resume-long-profile suggest-manage-profile-div"
-        onClick={() => navigate(`/search/detail/${item.resume_id}`)}
+        onClick={handleProfileClick}
       >
         <img className="resume-card-profile" src={item.profile_image} />
         <div className="resume-card-contents">
           <div className="resume-title-container">
             <div className="resume-card-title">
-              {item.progress === 'is_paid' ? item.name : blurName(item.name)}
+              {item.progress === 'is_paid' || item.progress === 'is_reviewed'
+                ? item.name
+                : blurName(item.name)}
             </div>
             <div className="resume-card-tags">
               <div className="resume-tag blue-tag">{item.commute_type}</div>
@@ -61,7 +79,7 @@ const ManagementItem = ({ item }: ManagementItemProps) => {
       </div>
       <div
         className="resume-long-sub suggest-manage-profile-div"
-        onClick={() => navigate(`/search/detail/${item.resume_id}`)}
+        onClick={handleProfileClick}
       >
         <div className="resume-card-job">
           {item.job_group} {`>`} {item.job_name}

--- a/src/components/suggestionpage/payment/PaidResume.tsx
+++ b/src/components/suggestionpage/payment/PaidResume.tsx
@@ -1,4 +1,5 @@
 import Contact from 'components/_common/Contact';
+import ReviewList from 'components/reviewpage/ReviewList';
 import ResumeDetailCard from 'components/searchpage/ResumeDetailCard';
 import SeniorDetail from 'components/searchpage/SeniorDetail';
 import SeniorIntro from 'components/searchpage/SeniorIntro';
@@ -12,12 +13,14 @@ const PaidResume = () => {
   const tabType = [
     { label: '이력서', user: 'resume' },
     { label: '전문가 소개', user: 'senior_info' },
+    { label: '리뷰', user: 'review' },
   ];
 
   return (
     <div className="sub-container">
       <ResumeDetailCard
         profileImage={resumeData.profile_image}
+        review_avg={resumeData.review_avg}
         seniorName={resumeData.name}
         jobGroup={resumeData.job_group}
         jobName={resumeData.job_role}
@@ -46,7 +49,9 @@ const PaidResume = () => {
           ))}
         </div>
       </div>
-      {activeIndex == 0 ? <SeniorDetail /> : <SeniorIntro />}
+      {activeIndex == 0 && <SeniorDetail />}
+      {activeIndex == 1 && <SeniorIntro />}
+      {activeIndex == 2 && <ReviewList />}
     </div>
   );
 };


### PR DESCRIPTION
## 개요

- 완료된 채용 탭에서 프로필을 클릭할 경우 PaidResumePage로 이동하도록 수정
- 해당 페이지로 이동 시 resume detail을 불러오는 api를 호출해서 리코일에 저장한 후 이동
- ResumeDetailAtom에 저장할 때 review_avg를 추가하도록 수정(ManagementItem 컴포넌트)
- PaidResumePage에서 리뷰 탭 추가

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
